### PR TITLE
Implement missing Spot API methods

### DIFF
--- a/dist/src/spot/models.d.ts
+++ b/dist/src/spot/models.d.ts
@@ -41,6 +41,12 @@ export interface OrderBookGroupResponse {
     sellQuote: OrderBookQuote[];
     timestamp: number;
 }
+export interface OrderBookResponse {
+    symbol: string;
+    buyQuote: OrderBookQuote[];
+    timestamp: number;
+    depth: number;
+}
 export interface TradeItem {
     price: number;
     size: number;
@@ -69,6 +75,17 @@ export interface CreateOrderRequest {
     clOrderID?: string;
     stealth?: number;
     deviation?: number;
+}
+export interface AmendOrderRequest {
+    symbol: string;
+    orderID?: string;
+    clOrderID?: string;
+    type: string;
+    value?: number;
+    slide?: boolean;
+    orderPrice?: number;
+    orderSize?: number;
+    triggerPrice?: number;
 }
 export interface OrderInfo {
     status: number;

--- a/dist/src/spot/spotApi.d.ts
+++ b/dist/src/spot/spotApi.d.ts
@@ -1,5 +1,5 @@
 import { BaseClient } from '../core/baseClient';
-import { MarketSummaryResponse, ChartingResponse, PriceResponse, OrderBookGroupResponse, TradeResponse, TimeResponse, CreateOrderRequest, OrderResponse } from './models';
+import { MarketSummaryResponse, ChartingResponse, PriceResponse, OrderBookGroupResponse, OrderBookResponse, TradeResponse, TimeResponse, CreateOrderRequest, AmendOrderRequest, OrderResponse } from './models';
 export declare class SpotApi extends BaseClient {
     getMarketSummary(symbol?: string): Promise<MarketSummaryResponse>;
     getOhlcv(symbol: string, options?: {
@@ -9,6 +9,7 @@ export declare class SpotApi extends BaseClient {
     }): Promise<ChartingResponse>;
     getPrice(symbol: string): Promise<PriceResponse>;
     getOrderbook(symbol: string, group?: string, limit_bids?: string, limit_asks?: string): Promise<OrderBookGroupResponse>;
+    getOrderbookL2(symbol: string, depth?: number): Promise<OrderBookResponse>;
     getTrades(symbol: string, options?: {
         startTime?: number;
         endTime?: number;
@@ -16,6 +17,9 @@ export declare class SpotApi extends BaseClient {
     }): Promise<TradeResponse>;
     getTime(): Promise<TimeResponse>;
     createOrder(req: CreateOrderRequest): Promise<OrderResponse>;
+    amendOrder(req: AmendOrderRequest): Promise<OrderResponse>;
+    createPegOrder(req: CreateOrderRequest): Promise<OrderResponse>;
+    cancelAllAfter(timeout: number): Promise<void>;
     cancelOrder(symbol: string, orderID?: string, clOrderID?: string): Promise<OrderResponse>;
     queryOrder(orderID?: string, clOrderID?: string): Promise<OrderResponse>;
     getOpenOrders(symbol: string, options?: {

--- a/dist/src/spot/spotApi.js
+++ b/dist/src/spot/spotApi.js
@@ -22,6 +22,12 @@ class SpotApi extends baseClient_1.BaseClient {
             params.limit_asks = limit_asks;
         return this.request('GET', '/api/v3.2/orderbook', params);
     }
+    getOrderbookL2(symbol, depth) {
+        const params = { symbol };
+        if (depth !== undefined)
+            params.depth = depth;
+        return this.request('GET', '/api/v3.2/orderbook/L2', params);
+    }
     getTrades(symbol, options = {}) {
         return this.request('GET', '/api/v3.2/trades', { symbol, ...options });
     }
@@ -30,6 +36,15 @@ class SpotApi extends baseClient_1.BaseClient {
     }
     createOrder(req) {
         return this.request('POST', '/api/v3.2/order', req, true);
+    }
+    amendOrder(req) {
+        return this.request('PUT', '/api/v3.2/order', req, true);
+    }
+    createPegOrder(req) {
+        return this.request('POST', '/api/v3.2/order/peg', req, true);
+    }
+    cancelAllAfter(timeout) {
+        return this.request('POST', '/api/v3.2/order/cancelAllAfter', { timeout }, true);
     }
     cancelOrder(symbol, orderID, clOrderID) {
         const params = { symbol };

--- a/src/spot/models.ts
+++ b/src/spot/models.ts
@@ -46,6 +46,13 @@ export interface OrderBookGroupResponse {
   timestamp: number;
 }
 
+export interface OrderBookResponse {
+  symbol: string;
+  buyQuote: OrderBookQuote[];
+  timestamp: number;
+  depth: number;
+}
+
 export interface TradeItem {
   price: number;
   size: number;
@@ -76,6 +83,18 @@ export interface CreateOrderRequest {
   clOrderID?: string;
   stealth?: number;
   deviation?: number;
+}
+
+export interface AmendOrderRequest {
+  symbol: string;
+  orderID?: string;
+  clOrderID?: string;
+  type: string;
+  value?: number;
+  slide?: boolean;
+  orderPrice?: number;
+  orderSize?: number;
+  triggerPrice?: number;
 }
 
 export interface OrderInfo {

--- a/src/spot/spotApi.ts
+++ b/src/spot/spotApi.ts
@@ -4,9 +4,11 @@ import {
   ChartingResponse,
   PriceResponse,
   OrderBookGroupResponse,
+  OrderBookResponse,
   TradeResponse,
   TimeResponse,
   CreateOrderRequest,
+  AmendOrderRequest,
   OrderResponse,
 } from './models';
 
@@ -31,6 +33,12 @@ export class SpotApi extends BaseClient {
     return this.request('GET', '/api/v3.2/orderbook', params);
   }
 
+  getOrderbookL2(symbol: string, depth?: number): Promise<OrderBookResponse> {
+    const params: any = { symbol };
+    if (depth !== undefined) params.depth = depth;
+    return this.request('GET', '/api/v3.2/orderbook/L2', params);
+  }
+
   getTrades(symbol: string, options: { startTime?: number; endTime?: number; count?: number } = {}): Promise<TradeResponse> {
     return this.request('GET', '/api/v3.2/trades', { symbol, ...options });
   }
@@ -41,6 +49,18 @@ export class SpotApi extends BaseClient {
 
   createOrder(req: CreateOrderRequest): Promise<OrderResponse> {
     return this.request('POST', '/api/v3.2/order', req, true);
+  }
+
+  amendOrder(req: AmendOrderRequest): Promise<OrderResponse> {
+    return this.request('PUT', '/api/v3.2/order', req, true);
+  }
+
+  createPegOrder(req: CreateOrderRequest): Promise<OrderResponse> {
+    return this.request('POST', '/api/v3.2/order/peg', req, true);
+  }
+
+  cancelAllAfter(timeout: number): Promise<void> {
+    return this.request('POST', '/api/v3.2/order/cancelAllAfter', { timeout }, true);
   }
 
   cancelOrder(symbol: string, orderID?: string, clOrderID?: string): Promise<OrderResponse> {


### PR DESCRIPTION
## Summary
- implement missing Spot API methods and models
- add Orderbook L2, amend order, peg order creation, and cancelAllAfter

## Testing
- `npm test`