### PR TITLE
Add futures API endpoints

### DIFF
--- a/dist/src/futures/futuresApi.d.ts
+++ b/dist/src/futures/futuresApi.d.ts
@@ -1,3 +1,99 @@
-import { BaseClient } from '../core/baseClient';
+import { BaseClient, ClientConfig } from '../core/baseClient';
+import { MarketSummaryResponse, ChartingResponse, PriceResponse, OrderBookGroupResponse, OrderBookResponse, TradeResponse, OrderResponse } from '../spot/models';
+import { FuturesCreateOrderRequest, FuturesAmendOrderRequest, ClosePositionRequest, RiskLimitRequest, LeverageRequest, SettleInRequest, BindTPSLRequest, TransferRequest } from './models';
 export declare class FuturesApi extends BaseClient {
+    constructor(config?: ClientConfig);
+    getMarketSummary(options?: {
+        symbol?: string;
+        useNewSymbolNaming?: boolean;
+        listFullAttributes?: boolean;
+    }): Promise<MarketSummaryResponse>;
+    getOhlcv(symbol: string, options: {
+        start?: string;
+        end?: string;
+        resolution: string;
+    }): Promise<ChartingResponse>;
+    getPrice(symbol?: string, useNewSymbolNaming?: boolean): Promise<PriceResponse>;
+    getOrderbook(symbol: string, useNewSymbolNaming?: boolean): Promise<OrderBookGroupResponse>;
+    getOrderbookL2(symbol: string, options?: {
+        depth?: number;
+        useNewSymbolNaming?: boolean;
+    }): Promise<OrderBookResponse>;
+    getTrades(symbol: string, options?: {
+        startTime?: string;
+        endTime?: string;
+        beforeSerialId?: string;
+        afterSerialId?: string;
+        count?: number;
+        useNewSymbolNaming?: boolean;
+    }): Promise<TradeResponse>;
+    getFundingHistory(options?: {
+        symbol?: string;
+        count?: number;
+        from?: number;
+        to?: number;
+        useNewSymbolNaming?: boolean;
+    }): Promise<any>;
+    createOrder(req: FuturesCreateOrderRequest): Promise<OrderResponse>;
+    amendOrder(req: FuturesAmendOrderRequest): Promise<OrderResponse>;
+    cancelOrder(symbol: string, params?: {
+        orderID?: string;
+        clOrderID?: string;
+    }): Promise<OrderResponse>;
+    queryOrder(params?: {
+        orderID?: string;
+        clOrderID?: string;
+    }): Promise<OrderResponse>;
+    createPegOrder(req: FuturesCreateOrderRequest): Promise<OrderResponse>;
+    cancelAllAfter(timeout: number): Promise<void>;
+    getOpenOrders(symbol: string, options?: {
+        orderID?: string;
+        clOrderID?: string;
+        useNewSymbolNaming?: boolean;
+    }): Promise<any>;
+    getTradeHistory(symbol: string, options?: {
+        startTime?: string;
+        endTime?: string;
+        beforeSerialId?: string;
+        afterSerialId?: string;
+        count?: number;
+        clOrderID?: string;
+        orderID?: string;
+        useNewSymbolNaming?: boolean;
+    }): Promise<any>;
+    getPositions(options?: {
+        symbol?: string;
+        useNewSymbolNaming?: boolean;
+    }): Promise<any>;
+    closePosition(req: ClosePositionRequest): Promise<any>;
+    getRiskLimit(symbol: string): Promise<any>;
+    setRiskLimit(req: RiskLimitRequest): Promise<any>;
+    getLeverage(symbol: string): Promise<any>;
+    setLeverage(req: LeverageRequest): Promise<any>;
+    settleIn(req: SettleInRequest): Promise<any>;
+    getFees(symbol?: string, useNewSymbolNaming?: boolean): Promise<any>;
+    bindTPSL(req: BindTPSLRequest): Promise<any>;
+    getPositionMode(symbol?: string): Promise<any>;
+    setPositionMode(req: {
+        symbol: string;
+        positionMode: string;
+    }): Promise<any>;
+    getWallet(params: {
+        wallet: string;
+        useNewSymbolNaming?: boolean;
+    }): Promise<any>;
+    getWalletHistory(options?: {
+        wallet?: string;
+        startTime?: string;
+        endTime?: string;
+        count?: number;
+        useNewSymbolNaming?: boolean;
+    }): Promise<any>;
+    getMargin(params: {
+        symbol: string;
+        startTime?: string;
+        endTime?: string;
+        count?: number;
+    }): Promise<any>;
+    transferWallet(req: TransferRequest): Promise<any>;
 }

--- a/dist/src/futures/futuresApi.js
+++ b/dist/src/futures/futuresApi.js
@@ -3,5 +3,115 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.FuturesApi = void 0;
 const baseClient_1 = require("../core/baseClient");
 class FuturesApi extends baseClient_1.BaseClient {
+    constructor(config = {}) {
+        const baseURL = config.baseURL || 'https://api.bitqik.com/futures';
+        super({ ...config, baseURL });
+    }
+    getMarketSummary(options = {}) {
+        return this.request('GET', '/api/v2.1/market_summary', options);
+    }
+    getOhlcv(symbol, options) {
+        return this.request('GET', '/api/v2.1/ohlcv', { symbol, ...options });
+    }
+    getPrice(symbol, useNewSymbolNaming) {
+        const params = {};
+        if (symbol)
+            params.symbol = symbol;
+        if (useNewSymbolNaming !== undefined)
+            params.useNewSymbolNaming = useNewSymbolNaming;
+        return this.request('GET', '/api/v2.1/price', params);
+    }
+    getOrderbook(symbol, useNewSymbolNaming) {
+        const params = { symbol };
+        if (useNewSymbolNaming !== undefined)
+            params.useNewSymbolNaming = useNewSymbolNaming;
+        return this.request('GET', '/api/v2.1/orderbook', params);
+    }
+    getOrderbookL2(symbol, options = {}) {
+        return this.request('GET', '/api/v2.1/orderbook/L2', { symbol, ...options });
+    }
+    getTrades(symbol, options = {}) {
+        return this.request('GET', '/api/v2.1/trades', { symbol, ...options });
+    }
+    getFundingHistory(options = {}) {
+        return this.request('GET', '/api/v2.1/funding_history', options);
+    }
+    createOrder(req) {
+        return this.request('POST', '/api/v2.1/order', req, true);
+    }
+    amendOrder(req) {
+        return this.request('PUT', '/api/v2.1/order', req, true);
+    }
+    cancelOrder(symbol, params = {}) {
+        return this.request('DELETE', '/api/v2.1/order', { symbol, ...params }, true);
+    }
+    queryOrder(params = {}) {
+        return this.request('GET', '/api/v2.1/order', params, true);
+    }
+    createPegOrder(req) {
+        return this.request('POST', '/api/v2.1/order/peg', req, true);
+    }
+    cancelAllAfter(timeout) {
+        return this.request('POST', '/api/v2.1/order/cancelAllAfter', { timeout }, true);
+    }
+    getOpenOrders(symbol, options = {}) {
+        return this.request('GET', '/api/v2.1/user/open_orders', { symbol, ...options }, true);
+    }
+    getTradeHistory(symbol, options = {}) {
+        return this.request('GET', '/api/v2.1/user/trade_history', { symbol, ...options }, true);
+    }
+    getPositions(options = {}) {
+        return this.request('GET', '/api/v2.1/user/positions', options, true);
+    }
+    closePosition(req) {
+        return this.request('POST', '/api/v2.1/order/close_position', req, true);
+    }
+    getRiskLimit(symbol) {
+        return this.request('GET', '/api/v2.1/risk_limit', { symbol }, true);
+    }
+    setRiskLimit(req) {
+        return this.request('POST', '/api/v2.1/risk_limit', req, true);
+    }
+    getLeverage(symbol) {
+        return this.request('GET', '/api/v2.1/leverage', { symbol }, true);
+    }
+    setLeverage(req) {
+        return this.request('POST', '/api/v2.1/leverage', req, true);
+    }
+    settleIn(req) {
+        return this.request('POST', '/api/v2.1/settle_in', req, true);
+    }
+    getFees(symbol, useNewSymbolNaming) {
+        const params = {};
+        if (symbol)
+            params.symbol = symbol;
+        if (useNewSymbolNaming !== undefined)
+            params.useNewSymbolNaming = useNewSymbolNaming;
+        return this.request('GET', '/api/v2.1/user/fees', params, true);
+    }
+    bindTPSL(req) {
+        return this.request('POST', '/api/v2.1/order/bind/tpsl', req, true);
+    }
+    getPositionMode(symbol) {
+        const params = {};
+        if (symbol)
+            params.symbol = symbol;
+        return this.request('GET', '/api/v2.1/position_mode', params, true);
+    }
+    setPositionMode(req) {
+        return this.request('POST', '/api/v2.1/position_mode', req, true);
+    }
+    getWallet(params) {
+        return this.request('GET', '/api/v2.1/user/wallet', params, true);
+    }
+    getWalletHistory(options = {}) {
+        return this.request('GET', '/api/v2.1/user/wallet_history', options, true);
+    }
+    getMargin(params) {
+        return this.request('GET', '/api/v2.1/user/margin', params, true);
+    }
+    transferWallet(req) {
+        return this.request('POST', '/api/v2.1/user/wallet/transfer', req, true);
+    }
 }
 exports.FuturesApi = FuturesApi;

--- a/dist/src/futures/models.d.ts
+++ b/dist/src/futures/models.d.ts
@@ -1,0 +1,76 @@
+export * from '../spot/models';
+export interface FuturesCreateOrderRequest {
+    symbol: string;
+    price?: number;
+    size: number;
+    side: 'BUY' | 'SELL';
+    time_in_force?: string;
+    type: string;
+    txType?: string;
+    stopPrice?: number;
+    triggerPrice?: number;
+    trailValue?: number;
+    postOnly?: boolean;
+    reduceOnly?: boolean;
+    clOrderID?: string;
+    trigger?: string;
+    takeProfitPrice?: number;
+    takeProfitTrigger?: string;
+    stopLossPrice?: number;
+    stopLossTrigger?: string;
+    positionMode?: string;
+}
+export interface FuturesAmendOrderRequest {
+    symbol: string;
+    orderID?: string;
+    clOrderID?: string;
+    type: string;
+    value?: number;
+    slide?: boolean;
+    orderPrice?: number;
+    orderSize?: number;
+    triggerPrice?: number;
+}
+export interface ClosePositionRequest {
+    price?: number;
+    symbol: string;
+    type: 'LIMIT' | 'MARKET';
+    positionId?: string;
+}
+export interface RiskLimitRequest {
+    symbol: string;
+    riskLimit: number;
+    positionMode?: string;
+    useNewSymbolNaming?: boolean;
+}
+export interface LeverageRequest {
+    symbol: string;
+    leverage: number;
+    useNewSymbolNaming?: boolean;
+    positionMode?: string | number;
+    marginMode?: string | number;
+}
+export interface SettleInRequest {
+    symbol: string;
+    currency: string;
+    positionId?: string;
+}
+export interface BindTPSLRequest {
+    symbol: string;
+    side?: string;
+    takeProfitPrice?: number;
+    takeProfitTrigger?: string;
+    stopLossPrice?: number;
+    stopLossTrigger?: string;
+    positionMode?: string;
+}
+export interface TransferRequest {
+    walletSrc?: string;
+    walletSrcType: string;
+    walletDest?: string;
+    walletDestType: string;
+    apiWallets: Array<{
+        currency: string;
+        allBalance: boolean;
+    }>;
+}

--- a/dist/src/futures/models.js
+++ b/dist/src/futures/models.js
@@ -1,0 +1,17 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __exportStar = (this && this.__exportStar) || function(m, exports) {
+    for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+__exportStar(require("../spot/models"), exports);

--- a/dist/test/bitqikClient.test.js
+++ b/dist/test/bitqikClient.test.js
@@ -10,5 +10,5 @@ function assert(condition, msg) {
 }
 const client = new client_1.default();
 assert(typeof client.spot.getMarketSummary === 'function');
-assert(typeof client.futures === 'object');
+assert(typeof client.futures.getMarketSummary === 'function');
 console.log('SDK structure checks passed.');

--- a/src/futures/futuresApi.ts
+++ b/src/futures/futuresApi.ts
@@ -1,5 +1,157 @@
-import { BaseClient } from '../core/baseClient';
+import { BaseClient, ClientConfig } from '../core/baseClient';
+import {
+  MarketSummaryResponse,
+  ChartingResponse,
+  PriceResponse,
+  OrderBookGroupResponse,
+  OrderBookResponse,
+  TradeResponse,
+  OrderResponse,
+} from '../spot/models';
+import {
+  FuturesCreateOrderRequest,
+  FuturesAmendOrderRequest,
+  ClosePositionRequest,
+  RiskLimitRequest,
+  LeverageRequest,
+  SettleInRequest,
+  BindTPSLRequest,
+  TransferRequest,
+} from './models';
 
 export class FuturesApi extends BaseClient {
-  // Placeholder for futures endpoints
+  constructor(config: ClientConfig = {}) {
+    const baseURL = config.baseURL || 'https://api.bitqik.com/futures';
+    super({ ...config, baseURL });
+  }
+
+  getMarketSummary(options: { symbol?: string; useNewSymbolNaming?: boolean; listFullAttributes?: boolean } = {}): Promise<MarketSummaryResponse> {
+    return this.request('GET', '/api/v2.1/market_summary', options);
+  }
+
+  getOhlcv(symbol: string, options: { start?: string; end?: string; resolution: string }): Promise<ChartingResponse> {
+    return this.request('GET', '/api/v2.1/ohlcv', { symbol, ...options });
+  }
+
+  getPrice(symbol?: string, useNewSymbolNaming?: boolean): Promise<PriceResponse> {
+    const params: any = {};
+    if (symbol) params.symbol = symbol;
+    if (useNewSymbolNaming !== undefined) params.useNewSymbolNaming = useNewSymbolNaming;
+    return this.request('GET', '/api/v2.1/price', params);
+  }
+
+  getOrderbook(symbol: string, useNewSymbolNaming?: boolean): Promise<OrderBookGroupResponse> {
+    const params: any = { symbol };
+    if (useNewSymbolNaming !== undefined) params.useNewSymbolNaming = useNewSymbolNaming;
+    return this.request('GET', '/api/v2.1/orderbook', params);
+  }
+
+  getOrderbookL2(symbol: string, options: { depth?: number; useNewSymbolNaming?: boolean } = {}): Promise<OrderBookResponse> {
+    return this.request('GET', '/api/v2.1/orderbook/L2', { symbol, ...options });
+  }
+
+  getTrades(symbol: string, options: { startTime?: string; endTime?: string; beforeSerialId?: string; afterSerialId?: string; count?: number; useNewSymbolNaming?: boolean } = {}): Promise<TradeResponse> {
+    return this.request('GET', '/api/v2.1/trades', { symbol, ...options });
+  }
+
+  getFundingHistory(options: { symbol?: string; count?: number; from?: number; to?: number; useNewSymbolNaming?: boolean } = {}): Promise<any> {
+    return this.request('GET', '/api/v2.1/funding_history', options);
+  }
+
+  createOrder(req: FuturesCreateOrderRequest): Promise<OrderResponse> {
+    return this.request('POST', '/api/v2.1/order', req, true);
+  }
+
+  amendOrder(req: FuturesAmendOrderRequest): Promise<OrderResponse> {
+    return this.request('PUT', '/api/v2.1/order', req, true);
+  }
+
+  cancelOrder(symbol: string, params: { orderID?: string; clOrderID?: string } = {}): Promise<OrderResponse> {
+    return this.request('DELETE', '/api/v2.1/order', { symbol, ...params }, true);
+  }
+
+  queryOrder(params: { orderID?: string; clOrderID?: string } = {}): Promise<OrderResponse> {
+    return this.request('GET', '/api/v2.1/order', params, true);
+  }
+
+  createPegOrder(req: FuturesCreateOrderRequest): Promise<OrderResponse> {
+    return this.request('POST', '/api/v2.1/order/peg', req, true);
+  }
+
+  cancelAllAfter(timeout: number): Promise<void> {
+    return this.request('POST', '/api/v2.1/order/cancelAllAfter', { timeout }, true);
+  }
+
+  getOpenOrders(symbol: string, options: { orderID?: string; clOrderID?: string; useNewSymbolNaming?: boolean } = {}): Promise<any> {
+    return this.request('GET', '/api/v2.1/user/open_orders', { symbol, ...options }, true);
+  }
+
+  getTradeHistory(symbol: string, options: { startTime?: string; endTime?: string; beforeSerialId?: string; afterSerialId?: string; count?: number; clOrderID?: string; orderID?: string; useNewSymbolNaming?: boolean } = {}): Promise<any> {
+    return this.request('GET', '/api/v2.1/user/trade_history', { symbol, ...options }, true);
+  }
+
+  getPositions(options: { symbol?: string; useNewSymbolNaming?: boolean } = {}): Promise<any> {
+    return this.request('GET', '/api/v2.1/user/positions', options, true);
+  }
+
+  closePosition(req: ClosePositionRequest): Promise<any> {
+    return this.request('POST', '/api/v2.1/order/close_position', req, true);
+  }
+
+  getRiskLimit(symbol: string): Promise<any> {
+    return this.request('GET', '/api/v2.1/risk_limit', { symbol }, true);
+  }
+
+  setRiskLimit(req: RiskLimitRequest): Promise<any> {
+    return this.request('POST', '/api/v2.1/risk_limit', req, true);
+  }
+
+  getLeverage(symbol: string): Promise<any> {
+    return this.request('GET', '/api/v2.1/leverage', { symbol }, true);
+  }
+
+  setLeverage(req: LeverageRequest): Promise<any> {
+    return this.request('POST', '/api/v2.1/leverage', req, true);
+  }
+
+  settleIn(req: SettleInRequest): Promise<any> {
+    return this.request('POST', '/api/v2.1/settle_in', req, true);
+  }
+
+  getFees(symbol?: string, useNewSymbolNaming?: boolean): Promise<any> {
+    const params: any = {};
+    if (symbol) params.symbol = symbol;
+    if (useNewSymbolNaming !== undefined) params.useNewSymbolNaming = useNewSymbolNaming;
+    return this.request('GET', '/api/v2.1/user/fees', params, true);
+  }
+
+  bindTPSL(req: BindTPSLRequest): Promise<any> {
+    return this.request('POST', '/api/v2.1/order/bind/tpsl', req, true);
+  }
+
+  getPositionMode(symbol?: string): Promise<any> {
+    const params: any = {};
+    if (symbol) params.symbol = symbol;
+    return this.request('GET', '/api/v2.1/position_mode', params, true);
+  }
+
+  setPositionMode(req: { symbol: string; positionMode: string }): Promise<any> {
+    return this.request('POST', '/api/v2.1/position_mode', req, true);
+  }
+
+  getWallet(params: { wallet: string; useNewSymbolNaming?: boolean }): Promise<any> {
+    return this.request('GET', '/api/v2.1/user/wallet', params, true);
+  }
+
+  getWalletHistory(options: { wallet?: string; startTime?: string; endTime?: string; count?: number; useNewSymbolNaming?: boolean } = {}): Promise<any> {
+    return this.request('GET', '/api/v2.1/user/wallet_history', options, true);
+  }
+
+  getMargin(params: { symbol: string; startTime?: string; endTime?: string; count?: number }): Promise<any> {
+    return this.request('GET', '/api/v2.1/user/margin', params, true);
+  }
+
+  transferWallet(req: TransferRequest): Promise<any> {
+    return this.request('POST', '/api/v2.1/user/wallet/transfer', req, true);
+  }
 }

--- a/src/futures/models.ts
+++ b/src/futures/models.ts
@@ -1,0 +1,81 @@
+export * from '../spot/models';
+
+export interface FuturesCreateOrderRequest {
+  symbol: string;
+  price?: number;
+  size: number;
+  side: 'BUY' | 'SELL';
+  time_in_force?: string;
+  type: string;
+  txType?: string;
+  stopPrice?: number;
+  triggerPrice?: number;
+  trailValue?: number;
+  postOnly?: boolean;
+  reduceOnly?: boolean;
+  clOrderID?: string;
+  trigger?: string;
+  takeProfitPrice?: number;
+  takeProfitTrigger?: string;
+  stopLossPrice?: number;
+  stopLossTrigger?: string;
+  positionMode?: string;
+}
+
+export interface FuturesAmendOrderRequest {
+  symbol: string;
+  orderID?: string;
+  clOrderID?: string;
+  type: string;
+  value?: number;
+  slide?: boolean;
+  orderPrice?: number;
+  orderSize?: number;
+  triggerPrice?: number;
+}
+
+export interface ClosePositionRequest {
+  price?: number;
+  symbol: string;
+  type: 'LIMIT' | 'MARKET';
+  positionId?: string;
+}
+
+export interface RiskLimitRequest {
+  symbol: string;
+  riskLimit: number;
+  positionMode?: string;
+  useNewSymbolNaming?: boolean;
+}
+
+export interface LeverageRequest {
+  symbol: string;
+  leverage: number;
+  useNewSymbolNaming?: boolean;
+  positionMode?: string | number;
+  marginMode?: string | number;
+}
+
+export interface SettleInRequest {
+  symbol: string;
+  currency: string;
+  positionId?: string;
+}
+
+export interface BindTPSLRequest {
+  symbol: string;
+  side?: string;
+  takeProfitPrice?: number;
+  takeProfitTrigger?: string;
+  stopLossPrice?: number;
+  stopLossTrigger?: string;
+  positionMode?: string;
+}
+
+export interface TransferRequest {
+  walletSrc?: string;
+  walletSrcType: string;
+  walletDest?: string;
+  walletDestType: string;
+  apiWallets: Array<{ currency: string; allBalance: boolean }>;
+}

--- a/test/bitqikClient.test.ts
+++ b/test/bitqikClient.test.ts
@@ -6,5 +6,5 @@ function assert(condition: boolean, msg?: string) {
 
 const client = new BitqikClient();
 assert(typeof client.spot.getMarketSummary === 'function');
-assert(typeof client.futures === 'object');
+assert(typeof client.futures.getMarketSummary === 'function');
 console.log('SDK structure checks passed.');


### PR DESCRIPTION
## Summary
- implement FuturesApi with methods for major futures endpoints
- add request model definitions for futures features
- update tests for new Futures API

## Testing
- `npm test`
- `npm run build`